### PR TITLE
Update example to use PySide6

### DIFF
--- a/examples/qt_avbmodel.py
+++ b/examples/qt_avbmodel.py
@@ -5,7 +5,7 @@ from __future__ import (
     division,
     )
 import sys
-from PySide2 import QtCore
+from PySide6 import QtCore
 
 import avb
 
@@ -191,7 +191,7 @@ class AVBModel(QtCore.QAbstractItemModel):
 
 if __name__ == "__main__":
 
-    from PySide2 import QtWidgets
+    from PySide6 import QtWidgets
     from optparse import OptionParser
 
     parser = OptionParser()


### PR DESCRIPTION
Update PySide2 imports to PySide6 to support latest QT version which is easier to install on Apple silicon machines.